### PR TITLE
Add support for unmarshalling collection elements

### DIFF
--- a/src/main/java/mx/kenzie/grammar/Grammar.java
+++ b/src/main/java/mx/kenzie/grammar/Grammar.java
@@ -126,13 +126,18 @@ public class Grammar {
             this.unmarshal(sub, expected, child);
         } else if (Collection.class.isAssignableFrom(expected) && value instanceof Collection<?> list) {
             final Collection replacement;
+            Class<?> expectedElement = Object.class;
+            if (field.getGenericType() instanceof ParameterizedType parameterized) {
+                final Type[] types = parameterized.getActualTypeArguments();
+                if (types.length == 1) expectedElement = (Class<?>) types[0];
+            }
             if (field.get(source) instanceof Collection current) (replacement = current).clear();
             else if (!Modifier.isAbstract(expected.getModifiers()))
                 replacement = (Collection) this.createObject(field.getType());
             else if (Set.class.isAssignableFrom(expected)) replacement = new LinkedHashSet();
             else if (List.class.isAssignableFrom(expected)) replacement = new ArrayList();
             else replacement = new LinkedList();
-            for (Object thing : list) replacement.add(this.construct(thing, Object.class));
+            for (Object thing : list) replacement.add(this.construct(thing, expectedElement));
             field.set(source, replacement);
         } else if (expected.isArray() && value instanceof Collection<?> list)
             field.set(source, this.constructArray(expected, list));

--- a/src/main/java/mx/kenzie/grammar/Grammar.java
+++ b/src/main/java/mx/kenzie/grammar/Grammar.java
@@ -118,7 +118,6 @@ public class Grammar {
                 else if (expected == float.class) field.setFloat(source, number.floatValue());
             }
         } else if (value == null) field.set(source, null);
-        else if (expected.isAssignableFrom(value.getClass())) field.set(source, value);
         else if (value instanceof Map<?, ?> child) {
             final Object sub, existing = field.get(source);
             if (existing == null) field.set(source, sub = this.createObject(expected));
@@ -141,6 +140,7 @@ public class Grammar {
             field.set(source, replacement);
         } else if (expected.isArray() && value instanceof Collection<?> list)
             field.set(source, this.constructArray(expected, list));
+        else if (expected.isAssignableFrom(value.getClass())) field.set(source, value);
         else throw new GrammarException("Value of '" + field.getName() + "' (" + source.getClass()
                     .getSimpleName() + ") could not be mapped to type " + expected.getSimpleName());
         //</editor-fold>

--- a/src/test/java/mx/kenzie/grammar/GrammarTest.java
+++ b/src/test/java/mx/kenzie/grammar/GrammarTest.java
@@ -57,6 +57,29 @@ public class GrammarTest {
     }
 
     @Test
+    public void testParametrizedList() {
+        class Foo {
+            int bar;
+            Foo(int bar) {
+                this.bar = bar;
+            }
+        }
+
+        class Thing {
+            List<Foo> list;
+        }
+
+        final Thing thing = new Thing();
+        thing.list = List.of(new Foo(13), new Foo(37));
+
+        final Grammar grammar = new Grammar();
+        final Map<String, Object> map = grammar.marshal(thing);
+        final Thing result = grammar.unmarshal(Thing.class, map);
+        assert result.list.get(0).bar == 13;
+        assert result.list.get(1).bar == 37;
+    }
+
+    @Test
     public void testShouldSkip() {
         final Grammar grammar = new Grammar();
         assert grammar.shouldSkip(field1);


### PR DESCRIPTION
Previously, attempting to unmarshal a `List<Map<String, Object>>` into a `List<MyType>` field would fail, because Grammar was unaware of the generic type of the List field. This PR implements functionality to take a guess at the type parametrisation of the field and unmarshal collection elements accordingly.